### PR TITLE
Feature/inputtext clear

### DIFF
--- a/src/components/InputText.vue
+++ b/src/components/InputText.vue
@@ -2,18 +2,32 @@
 type InputTextProps = {
   label: string;
 };
-const model = defineModel<string>();
+
 defineProps<InputTextProps>();
+
+const model = defineModel<string>();
+
+const clearInput = (event: MouseEvent) => {
+  model.value = "";
+};
 </script>
 
 <template>
-  <label class="flex flex-col gap-4">
+  <label class="flex flex-col gap-4 relative">
     {{ label }}
     <input
-      class="border-gray-400 border rounded-md h-10 px-4 hover:border-blue-400 invalid:border-red-500 focus:border-green-400 focus:outline-none"
+      class="border-gray-400 border rounded-md h-10 pl-4 pr-8 hover:border-blue-400 invalid:border-red-500 focus:border-green-400 focus:outline-none"
       type="text"
       autocomplete="off"
       v-model="model"
     />
+    <button
+      v-if="model && model.length > 0"
+      type="button"
+      class="absolute right-4 top-3/4 transform -translate-y-1/2 cursor-pointer"
+      @click="clearInput"
+    >
+      X
+    </button>
   </label>
 </template>

--- a/src/components/InputText.vue
+++ b/src/components/InputText.vue
@@ -7,8 +7,18 @@ defineProps<InputTextProps>();
 
 const model = defineModel<string>();
 
+const focusPreviousInput = (currentTarget: HTMLElement) => {
+  if (currentTarget?.previousElementSibling) {
+    const inputElement = currentTarget.previousElementSibling as HTMLInputElement;
+    inputElement.focus();
+  }
+};
+
 const clearInput = (event: MouseEvent) => {
   model.value = "";
+
+  const currentTarget = event.currentTarget as HTMLElement;
+  focusPreviousInput(currentTarget);
 };
 </script>
 


### PR DESCRIPTION
This pull request includes several changes to the `InputText.vue` component to enhance its functionality and improve user experience. The main changes include the addition of a clear button for the input field and the implementation of helper functions to manage input focus and clearing.

Enhancements to input functionality:

* [`src/components/InputText.vue`](diffhunk://#diff-48a640b5f3f8f1f261c4671e3df446a80240c00bd54485316cc68f5b3f23b6daL5-R41): Added a `clearInput` function to clear the input field and focus on the previous input element when the clear button is clicked.
* [`src/components/InputText.vue`](diffhunk://#diff-48a640b5f3f8f1f261c4671e3df446a80240c00bd54485316cc68f5b3f23b6daL5-R41): Introduced a `focusPreviousInput` helper function to handle focusing on the previous input element.
* [`src/components/InputText.vue`](diffhunk://#diff-48a640b5f3f8f1f261c4671e3df446a80240c00bd54485316cc68f5b3f23b6daL5-R41): Modified the input field to include a clear button that appears when the input has content, improving user experience.

Styling and template adjustments:

* [`src/components/InputText.vue`](diffhunk://#diff-48a640b5f3f8f1f261c4671e3df446a80240c00bd54485316cc68f5b3f23b6daL5-R41): Updated the input field's CSS classes to accommodate the new clear button and ensure proper spacing and alignment.